### PR TITLE
Release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Automated release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow for automated releases. The most important change is the update to trigger the workflow on tag pushes instead of branch pushes.

Workflow trigger update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R6): Changed the trigger from `push` on `main` branch to `push` on tags matching the pattern `v*.*.*`.